### PR TITLE
Failed action build. `add-path` command is disabled. 

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/setup-node@v2.1.1
         with:
           node-version: "14.x"
+        env:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: "2.6"


### PR DESCRIPTION
`actions/setup-node@v2.1.1`에
env: `ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'` 추가함