### PR TITLE
Fixed spaceship issue

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -21,6 +21,7 @@ jobs:
       - run: gem install bundler:2.1.4
       - run: bundle install
       - run: npm install
+      - run: gem install fastlane -v '2.219.0'
       - run: node Sources/check_status.js
         env:
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -17,7 +17,7 @@ jobs:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.6"
+          ruby-version: "2.7"
       - run: gem install bundler:2.1.4
       - run: bundle install
       - run: npm install


### PR DESCRIPTION
안녕하세요!
만들어주신 앱스토어 상태 봇 잘 사용하고 있습니다. 🙇🏻‍♂️

다른게 아니라 언제부턴가 앱스토어 상태가 갱신이 안되고 있는 것 같더라구요.
오류 로그를 보니 다음과 같은 문제가 발생하는 것을 확인하였습니다. 
![스크린샷 2024-03-06 오후 1 52 09](https://github.com/techinpark/appstore-status-bot/assets/60125719/ab012368-88f9-47dc-a277-378b4ee34588)

관련해서 찾아보니 fetch_app_status.rb파일에서 spaceship이라는 서드파티를 사용해서 앱스토어 정보를 읽어오는 부분을 인지했고, 
다음 이슈가 열려있는 것을 찾았습니다.
[https://github.com/fastlane/fastlane/issues/21819](https://github.com/fastlane/fastlane/issues/21819)

찾아보니 해당 이슈는 fastlane 2.219.0버전에서 수정이 된 것을 확인하였습니다. 

그래서 다음과 같이 수정하여 오류를 제거하였습니다.
 1. fastlane 2.219.0 버전을 설치하도록 스크립트를 수정하였습니다.
 2. fastlane 2.219.0 버전의 루비 최소버전 요구사항 때문에 루비 버전을 2.7 버전으로 수정하였습니다.
